### PR TITLE
Enable developer extras when WEBKIT_INSPECTOR_SERVER is defined

### DIFF
--- a/launcher/main.cpp
+++ b/launcher/main.cpp
@@ -143,6 +143,12 @@ int main(int argc, char* argv[])
     if (!g_getenv("WPE_SHELL_DISABLE_CONSOLE_LOG"))
       WKPreferencesSetLogsPageMessagesToSystemConsoleEnabled(preferences, true);
 
+    if (const char* value = g_getenv("WEBKIT_INSPECTOR_SERVER")) {
+        // Very naïve check for <ip>:<port>
+        if (strlen(value) > 2 && strchr(value, ':'))
+            WKPreferencesSetDeveloperExtrasEnabled(preferences, true);
+    }
+
     WKPageGroupSetPreferences(pageGroup, preferences);
 
     auto pageConfiguration  = WKPageConfigurationCreate();


### PR DESCRIPTION
It does make sense to enable the developer extras when the `WEBKIT_INSPECTOR_SERVER` environment variable has been set.

Related issue: WebPlatformForEmbedded/WPEWebKit#549